### PR TITLE
Always toggle to true except for formatOnType

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
+  "version": "1.1.2",
   "configurations": [
     {
       "name": "vscode-status-bar-format-toggle",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-status-bar-format-toggle",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-status-bar-format-toggle",
   "displayName": "Status bar formatting toggle",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A VS Code extension that allows you to toggle the formatter on and off with a simple click",
   "license": "MIT",
   "repository": {

--- a/src/helpers/initCommand.ts
+++ b/src/helpers/initCommand.ts
@@ -21,7 +21,8 @@ const initCommand = (
   initialFormattingConfiguration: FormattingConfiguration,
   statusBar: StatusBarItem
 ): Disposable => {
-  // We should disable if any of the initial formatting setting is set to `true`.
+  // We should disable on the first toggle if any of the initial formatting
+  // setting is set to `true`.
   let shouldDisable = Object.values(initialFormattingConfiguration).some(
     Boolean
   )
@@ -33,9 +34,17 @@ const initCommand = (
         return editorConfiguration.update(setting, false, CONFIGURATION_TARGET)
       }
 
-      // Set the formatting setting back to its initial value.
-      const initialValue = initialFormattingConfiguration[setting]
-      editorConfiguration.update(setting, initialValue, CONFIGURATION_TARGET)
+      // `formatOnType` should only be toggled on if the user had enabled it
+      // beforehand.
+      // @FIXME: if `formatOnType` is set to `false` when VSCode is first
+      // launched, it will never be toggled on.
+      if (setting === 'formatOnType') {
+        const initialValue = initialFormattingConfiguration[setting]
+        return editorConfiguration.update(setting, initialValue, CONFIGURATION_TARGET)
+      }
+
+      // The two other settings are *probably* safe to be toggled on.
+      return editorConfiguration.update(setting, true, CONFIGURATION_TARGET)
     })
 
     shouldDisable = !shouldDisable


### PR DESCRIPTION
If all formatting settings were set to `false` when VSCode was launched, they would never get toggled on. This PR ensures that `formatOnPaste` and `formatOnSave` are always toggled on. `formatOnType` is only toggled on if it was enabled as part of the user’s config beforehand.